### PR TITLE
fix: status bar color

### DIFF
--- a/app/src/main/res/values-v29/themes.xml
+++ b/app/src/main/res/values-v29/themes.xml
@@ -4,7 +4,6 @@
         <item name="colorPrimary">@color/navigationBar</item>
         <item name="android:colorAccent">?android:attr/colorAccent</item>
         <item name="android:background">?android:attr/background</item>
-        <item name="android:windowLightStatusBar">true</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -5,7 +5,6 @@
         <item name="colorPrimary">@color/navigationBar</item>
         <item name="android:colorAccent">?android:attr/colorAccent</item>
         <item name="android:background">@android:color/system_neutral1_100</item>
-        <item name="android:windowLightStatusBar">true</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>


### PR DESCRIPTION
Removing the line `<item name="android:windowLightStatusBar">true</item>` from themes.xml did the trick.

I did some research on Material You and found out that if the user is using light mode, then the surface/background color in their color palette is light else it is dark.
So the default icon colors should work fine.

I couldn't test it very extensively tho because I do not have a phone which supports Material You.

**Screenshots**
1. Light mode

![Screenshot_20211021-155650](https://user-images.githubusercontent.com/68477362/138260535-30f89c87-0893-4033-bbcc-7dcc60be8107.jpg)


2. Dark mode

![Screenshot_20211021-155644](https://user-images.githubusercontent.com/68477362/138260548-0977139a-010d-41da-afe9-dd13db4f0d29.jpg)

Issue #17 