### PR TITLE
Add missing F-Droid link to GitHub page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,9 +34,9 @@ I've built Cofi after getting frustrated with the lack of privacy-respecting, sm
   <a href="https://github.com/rozPierog/Cofi/releases">
     <img src="assets/get-github.png" height="75">
   </a>
-  <!-- <a href="">
+  <a href="https://www.f-droid.org/en/packages/com.omelan.cofi/">
     <img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" height="75">
-  </a> -->
+  </a>
 </p>
 
 


### PR DESCRIPTION
I noticed that the F-Droid link is missing on the [GitHub page](https://rozpierog.github.io/Cofi/)