### PR TITLE
Fix web view theming

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -151,6 +151,8 @@ dependencies {
     implementation 'androidx.palette:palette-ktx:1.0.0'
     // Navigation
     implementation "androidx.navigation:navigation-compose:2.4.0-beta02"
+    // Webkit
+    implementation 'androidx.webkit:webkit:1.4.0'
 
     // Integration with observables
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"

--- a/app/src/main/java/com/omelan/cofi/components/WebView.kt
+++ b/app/src/main/java/com/omelan/cofi/components/WebView.kt
@@ -2,18 +2,36 @@ package com.omelan.cofi.components
 
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebSettingsCompat.FORCE_DARK_OFF
+import androidx.webkit.WebSettingsCompat.FORCE_DARK_ON
+import androidx.webkit.WebViewFeature
 
 @Composable
 fun WebView(urlToRender: String) {
+    val darkTheme = isSystemInDarkTheme()
     AndroidView(
         factory = { context ->
             val webView = WebView(context)
             webView.webViewClient = WebViewClient()
             webView.loadUrl(urlToRender)
             return@AndroidView webView
+        },
+        update = { webView ->
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+                if (darkTheme) {
+                    WebSettingsCompat.setForceDark(webView.settings, FORCE_DARK_ON)
+                } else {
+                    WebSettingsCompat.setForceDark(webView.settings, FORCE_DARK_OFF)
+                }
+            }
         }
     )
 }

--- a/app/src/main/java/com/omelan/cofi/components/WebView.kt
+++ b/app/src/main/java/com/omelan/cofi/components/WebView.kt
@@ -2,11 +2,8 @@ package com.omelan.cofi.components
 
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.webkit.WebSettingsCompat


### PR DESCRIPTION
Currently the licenses web view always uses light mode.

With this PR I updated the web view to use night theme if dark mode is enabled and the web view does support dark mode.

There is an issue I noticed with my implementation. If you enable dark mode on your device and open the web view it flashes white. I'm not quite sure why this happens.

To force dark mode of the web view I had to add a library. I didn't add it to the licenses html file, yet. Do you update the html file manually or do you have script for this?