### PR TITLE
Can't save recipes without name and description 

### DIFF
--- a/app/src/main/java/com/omelan/cofi/MainActivity.kt
+++ b/app/src/main/java/com/omelan/cofi/MainActivity.kt
@@ -193,12 +193,12 @@ class MainActivity : MonetCompatActivity() {
 
     @Composable
     fun MainAddRecipe(goBack: () -> Unit, db: AppDatabase) {
-        var isRecipeSave: Boolean = false
+        var isRecipeSave = false
         RecipeEdit(
             saveRecipe = { recipe, steps ->
                 lifecycleScope.launch {
           
-           if(!recipe.name.isNullOrBlank() and !recipe.description.isNullOrBlank()) {
+           if(recipe.name.isNotBlank() and recipe.description.isNotBlank()) {
                     val idOfRecipe =
                         db.recipeDao().insertRecipe(recipe)
                     db.stepDao()

--- a/app/src/main/java/com/omelan/cofi/MainActivity.kt
+++ b/app/src/main/java/com/omelan/cofi/MainActivity.kt
@@ -193,9 +193,12 @@ class MainActivity : MonetCompatActivity() {
 
     @Composable
     fun MainAddRecipe(goBack: () -> Unit, db: AppDatabase) {
+        var isRecipeSave: Boolean = false
         RecipeEdit(
             saveRecipe = { recipe, steps ->
                 lifecycleScope.launch {
+          
+           if(!recipe.name.isNullOrBlank() and !recipe.description.isNullOrBlank()) {
                     val idOfRecipe =
                         db.recipeDao().insertRecipe(recipe)
                     db.stepDao()
@@ -204,9 +207,17 @@ class MainActivity : MonetCompatActivity() {
                                 it.copy(recipeId = idOfRecipe.toInt())
                             }
                         )
+                                    isRecipeSave=true
+                    }else{Toast.makeText(applicationContext,"Name and description can't be empty.",Toast.LENGTH_SHORT).show()  }
+
+                    if(isRecipeSave.equals(true)  ){goBack()}
+
                 }
-                goBack()
+
             },
+            
+            
+            
             goBack = goBack,
         )
     }


### PR DESCRIPTION
# Description
Now users cant save recipes without entering the name and description, basically name and description won't be blank.

<!--- Please include a summary of the change and which issue is fixed. -->
I have added a simple if-else in MainActitvity.kt. If the name and description of recipe is empty, it will show a toast requesting user to enter the same.

## Type of change

<!--- Please delete options that are not relevant. -->
- [ ] Bug fix
