### PR TITLE
Fix about page list item icon alignment

### DIFF
--- a/app/src/main/java/com/omelan/cofi/pages/settings/About.kt
+++ b/app/src/main/java/com/omelan/cofi/pages/settings/About.kt
@@ -80,14 +80,14 @@ fun AppSettingsAbout(goBack: () -> Unit, openLicenses: () -> Unit) {
             }
             item {
                 ListItem(
-                    text = {
+                    overlineText = {
                         Text(
                             text = stringResource(id = R.string.hoffmann_credits_title),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
                     },
-                    secondaryText = {
+                    text = {
                         Text(
                             text = stringResource(id = R.string.hoffmann_credits_subtitle),
                             maxLines = 1,
@@ -108,14 +108,14 @@ fun AppSettingsAbout(goBack: () -> Unit, openLicenses: () -> Unit) {
             }
             item {
                 ListItem(
-                    text = {
+                    overlineText = {
                         Text(
                             text = stringResource(id = R.string.tereszkiewicz_credits_title),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
                     },
-                    secondaryText = {
+                    text = {
                         Text(
                             text = stringResource(id = R.string.tereszkiewicz_credits_subtitle),
                             maxLines = 1,

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Fix about page list item icon alignment
 
 ### Removed
 


### PR DESCRIPTION
# Description

<!--- Please include a summary of the change and which issue is fixed. -->

Fixes icon alignment on about page. Before icon wasn't centered with the text.

## Type of change

<!--- Please delete options that are not relevant. -->
- [x] Bug fix

# Checklist:

- [x] I've added new item into [Changelog](docs/Changelog.md) under [Unreleased]
- [x] I've tested the change on device
