### PR TITLE
docs: fix dead links in index.md

### DIFF
--- a/docs/Contribute/Language.md
+++ b/docs/Contribute/Language.md
@@ -6,11 +6,11 @@ permalink: /contribute/language.html
 # Contribute new language
 
 If you are familiar with the Android resource structure I'll be happy to accept Pull Request with a new language to Cofi!
-You can find always up to date English strings [here](/app/src/main/res/values/strings.xml)
+You can find always up to date English strings [here](https://github.com/rozPierog/Cofi/blob/main/app/src/main/res/values/strings.xml)
 
 If you don't know how to do any of the things I've mentioned above:
 
-- Open [English strings](/app/src/main/res/values/strings.xml)
+- Open [English strings](https://github.com/rozPierog/Cofi/blob/main/app/src/main/res/values/strings.xml)
 - Copy everything to your editor of choice
 - Translate stuff that's between `<string name="">` and `</string>`
 - Open Issue on GitHub and paste your translation there. Remember to add information about what language it is!

--- a/docs/Contribute/Recipe.md
+++ b/docs/Contribute/Recipe.md
@@ -20,7 +20,7 @@ A good contender for new default recipe:
 
 ## 🤖 If you are an Android developer:
 
-Everything you need to start is [here](/app/src/main/java/com/omelan/cofi/model/PrepopulateData.kt)
+Everything you need to start is [here](https://github.com/rozPierog/Cofi/blob/main/app/src/main/java/com/omelan/cofi/model/PrepopulateData.kt)
 
 1. Add next `<recipe_name>Id` - must be one higher than one above it
 2. Add Recipe object to the `recipes` list

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -20,6 +20,7 @@ gem "minima", git: "https://github.com/jekyll/minima"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
+  gem 'jekyll-relative-links'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
@@ -35,5 +36,3 @@ gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
 # kramdown v2 ships without the gfm parser by default. If you're using
 # kramdown v1, comment out this line.
 gem "kramdown-parser-gfm"
-
-

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-relative-links (0.6.1)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-seo-tag (2.7.1)
@@ -80,6 +82,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.9.0)
   jekyll-feed (~> 0.6)
+  jekyll-relative-links
   kramdown-parser-gfm
   minima!
   tzinfo (~> 1.2)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,6 +22,8 @@ include: [".well-known"]
 # Build settings
 markdown: kramdown
 theme: minima
+plugins:
+  - jekyll-relative-links
 header_pages:
   - Contribute/CONTRIBUTING.md
   - index.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,6 @@ I've built Cofi after getting frustrated with the lack of privacy-respecting, sm
 
 ## Contribute to Cofi
 
-- [New language](/docs/Contribute/Language.md)
-- [New default recipe](/docs/Contribute/Recipe.md)
-- [New feature or bugfix](/docs/Contribute/CONTRIBUTING.md)
+- [New language](Contribute/Language.md)
+- [New default recipe](Contribute/Recipe.md)
+- [New feature or bugfix](Contribute/CONTRIBUTING.md)


### PR DESCRIPTION
The PR #106 fixes the links in [`index.md`](https://github.com/rozPierog/Cofi/blob/b03d29591d0ec1fdd5ac4325e01a8af1c45c87ad/docs/index.md) but the corresponding links at the page https://rozpierog.github.io/Cofi/ are still incorrect. The problem is that `jekyll` does not resolve the relative links correctly. It seems that the best solution is to use the plugin [`jekyll-relative-links`](https://github.com/benbalter/jekyll-relative-links).

I hope that this PR solves the problem. I know that:
- the links work in [`index.md`](https://github.com/vil02/Cofi/blob/2905fc6d0925959bd62ff135947272128f90572a/docs/index.md),
- I have checked locally that the links work in the generated `index.html` file (cf. below), but this was kind of _hacky_ (I used Ruby 3.0, jekyll 3.9.2 and I needed to add webrick into the `Gemfile`).

The relevant piece of the generated `index.html` file:
```html
<ul>
  <li><a href="/Cofi/contribute/language.html">New language</a></li>
  <li><a href="/Cofi/contribute/recipe.html">New default recipe</a></li>
  <li><a href="/Cofi/contribute/code.html">New feature or bugfix</a></li>
</ul>
```