### PR TITLE
chore: update `actions/checkout` to `v4`

### DIFF
--- a/.github/workflows/Emulator.yml
+++ b/.github/workflows/Emulator.yml
@@ -26,7 +26,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set up JDK 1.19
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: set up JDK 1.19
       uses: actions/setup-java@v2
       with:

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -12,7 +12,7 @@ jobs:
             matrix:
                 build_type: [ benchmark ]
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: set up JDK 1.19
               uses: actions/setup-java@v2
               with:


### PR DESCRIPTION
# Description
The `actions/checkout@v4` was recently [released](https://github.com/actions/checkout/releases/tag/v4.0.0). This PR makes a suitable update.

