### PR TITLE
chore: update `actions/github-script` to `v6`

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -55,7 +55,7 @@ jobs:
                   COMMENT="${COMMENT//$'\n'/'%0A'}"
                   COMMENT="${COMMENT//$'\r'/'%0D'}"
                   echo "COMMENT=$COMMENT" >> $GITHUB_ENV
-            - uses: actions/github-script@v3
+            - uses: actions/github-script@v6
               with:
                   script: |
                       var comment = `${{ env.COMMENT }}`
@@ -63,7 +63,7 @@ jobs:
                       comment = comment.replace(/%0A/g, '\n')
                       comment = comment.replace(/%0D/g, '\r')
                       comment = "```" + comment + "```"
-                      github.issues.createComment({
+                      github.rest.issues.createComment({
                         issue_number: context.issue.number,
                         owner: context.repo.owner,
                         repo: context.repo.repo,


### PR DESCRIPTION
# Description

This PR updates the used version of `actions/github-scrip` to `v6` (the newest available at the moment). Please note that since the `Compare app size` workflow fails before `Run actions/github-script`-step I am not able to verify if the change really works. I am fine if this will be merged after the mentioned workflow will be fixed. 

It is similar to #218 and #220.