### PR TITLE
chore: update `actions/checkout` to `v4`

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -34,7 +34,7 @@ jobs:
                   cp ./app/build/outputs/apk/full/${{ matrix.build_type }}/app-full-${{ matrix.build_type }}.apk ../pr.apk
                   ls
 
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
               with:
                   ref: main
             - name: Build main app


### PR DESCRIPTION
# Description

This PR updates the `actions/checkout` to `v4` in [`size.yml`](https://github.com/rozPierog/Cofi/blob/5973297f4968d19a1681d5dda5cb88872d8ed34d/.github/workflows/size.yml#L37). Related to #218, #220 and #221.
