### PR TITLE
chore: update `ASzc/change-string-case-action` to `v5`

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -23,7 +23,7 @@ jobs:
             - name: Grant execute permission for gradlew
               run: chmod +x gradlew
             - id: type
-              uses: ASzc/change-string-case-action@v2
+              uses: ASzc/change-string-case-action@v5
               with:
                   string: ${{ matrix.build_type }}
             - name: Build PR app


### PR DESCRIPTION
# Description

<!--- Please include a summary of the change and which issue is fixed. -->

Another single byte change from me.
This PR updates the [`ASzc/change-string-case-action`](https://github.com/ASzc/change-string-case-action) to `v5`.
Related to #218, #220, #221 and #225.