### PR TITLE
chore: update `actions/setup-java` to `v4`

### DIFF
--- a/.github/workflows/Emulator.yml
+++ b/.github/workflows/Emulator.yml
@@ -28,7 +28,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
       - name: set up JDK 1.19
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '19'
           distribution: zulu

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: set up JDK 1.19
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '19'
         distribution: zulu

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -14,7 +14,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - name: set up JDK 1.19
-              uses: actions/setup-java@v3
+              uses: actions/setup-java@v4
               with:
                   java-version: '19'
                   distribution: zulu


### PR DESCRIPTION
# Description

This PR updates the used version of `actions/setup-java` to `v4` (the newest available at the moment).

It is similar to #220 .